### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run main.go"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Note:
 
 All characters have an ASCII value in [35, 126].
 1 <= len(chars) <= 1000.
+
+
+[![Run on Repl.it](https://repl.it/badge/github/jchenriquez/443)](https://repl.it/github/jchenriquez/443)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jchenriquez/443).